### PR TITLE
tweaks to pyodide.js to turn it into a Promise'd helper

### DIFF
--- a/pyodide.js
+++ b/pyodide.js
@@ -1,22 +1,35 @@
+/* eslint-disable */
+
 var pyodide = {}
 
-{
-    let baseURL = "https://iodide-project.github.io/pyodide-demo/";
-    let wasmURL = baseURL + 'pyodide.asm.wasm?x=' + Date.now();
-    let wasmXHR = new XMLHttpRequest();
-    wasmXHR.open('GET', wasmURL, true);
-    wasmXHR.responseType = 'arraybuffer';
-    wasmXHR.onload = function() {
-        if (wasmXHR.status === 200 || wasmXHR.status === 0) {
-            pyodide.wasmBinary = wasmXHR.response;
-        } else {
-            alert("Couldn't download the pyodide.asm.wasm binary.  Response was " + wasmXHR.status);
-        }
+var languagePluginLoader = new Promise((resolve, reject) => {
+  var baseURL = 'https://iodide-project.github.io/pyodide-demo/';
+  var wasmURL = `${baseURL}pyodide.asm.wasm?x=${Date.now()}`;
+  var wasmXHR = new XMLHttpRequest();
+  wasmXHR.open('GET', wasmURL, true);
+  wasmXHR.responseType = 'arraybuffer';
+  wasmXHR.onload = function () {
+    if (wasmXHR.status === 200 || wasmXHR.status === 0) {
+      pyodide.wasmBinary = wasmXHR.response;
+    } else {
+      alert(`Couldn't download the pyodide.asm.wasm binary.  Response was ${wasmXHR.status}`);
+    }
 
-        pyodide.baseURL = baseURL;
-        var script = document.createElement('script');
-        script.src = baseURL + "pyodide.asm.js";
-        document.body.appendChild(script);
-    };
-    wasmXHR.send(null);
-}
+    pyodide.baseURL = baseURL;
+    var script = document.createElement('script');
+    script.src = `${baseURL}pyodide.asm.js`;
+    script.onload = () => {
+      // setInterval hack until we can get a callback when compilation is complete.
+      var everythingLoaded = setInterval(() => {
+        if (pyodide.runPython !== undefined) {
+            clearInterval(everythingLoaded);
+            resolve()
+        }
+      }, 100);
+      
+    }
+    document.body.appendChild(script);
+  };
+  wasmXHR.send(null);
+})
+languagePluginLoader


### PR DESCRIPTION
I'm not sure if this is the right place to put this updated helper, but it is based on [iodide/#554](https://github.com/iodide-project/iodide/pull/554). Curious to know if you think this is the right approach. It functionally does the same thing, but gives a promise available to other systems (like iodide) to wait for resolution until everything is compiled.